### PR TITLE
Fix handling for absolute tagfile paths

### DIFF
--- a/src/tags.ts
+++ b/src/tags.ts
@@ -32,7 +32,13 @@ export default class Helptags extends BasicList {
     let result: ListItem[] = []
     await Promise.all(tagfiles.map(file => {
       return new Promise<void>(resolve => {
-        let filepath = path.join(cwd, file)
+        let filepath = ""
+        if (file.startsWith('/') {
+          filepath = file
+        }
+        else {
+          filepath = path.join(cwd, file)
+        }
         let dirname = path.dirname(filepath)
         const rl = readline.createInterface({
           input: fs.createReadStream(filepath, { encoding: 'utf8' }),


### PR DESCRIPTION
If a tagfile is not relative to the current directory, vim returns an
absolute path. `coc-lists` was assuming that all tagfiles would be
relative to the current working directory, and simply appended the
vim-returned paths to the current working directory path, resulting in
paths like `/home/user/project1/home/user/project2/tags`.

This checks for a leading `/` on returned tagfile-paths, and skips
prepending the current working directory if necessary.