### PR TITLE
fix(session): fix location

### DIFF
--- a/src/session.ts
+++ b/src/session.ts
@@ -34,7 +34,7 @@ export default class SessionList extends BasicList {
         name = await nvim.getVvar('this_session') as string
         if (!name) {
           let defaultValue = path.basename(workspace.rootPath)
-          name = await workspace.requestInput('session name:', defaultValue)
+          name = await workspace.requestInput('session name', defaultValue)
           if (!name) return
         }
       }
@@ -163,13 +163,12 @@ export default class SessionList extends BasicList {
     })
     files = arr.map(o => o.filepath)
     return files.map(filepath => {
-      filepath = filepath.replace(os.homedir(), '~')
       let uri = Uri.file(filepath).toString()
       let location = Location.create(uri, range)
       let name = path.basename(filepath, '.vim')
       let active = curr && curr == filepath
       return {
-        label: `${active ? '*' : ' '} ${name}\t${uri}`,
+        label: `${active ? '*' : ' '} ${name}\t${filepath}`,
         data: { filepath },
         location
       }


### PR DESCRIPTION
1. 166 行的替换（貌似是非必需的）导致 167 行的 `uri` 为 `file:///~/path_to_session_file`

e.g. 我电脑上`filepath` 为 `/home/voldikss/.cache/nvim/session/default.vim`， 得到的 `uri` 变成 `file:///~/.cache/nvim/session/default.vim`，然后`delete``open` 这些操作由于路径不会所以都不起作用。

https://github.com/neoclide/coc-lists/blob/c3cc9a52a2670ea8665f9b0e862ab6116c3c1f9f/src/session.ts#L165-L177

2. `session name:`-> `session name` 冒号多余
3. `uri`->`filepath`感觉显示路径比显示 uri 更友好