### PR TITLE
add filter by name for files&mru (#126)

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,11 @@
             "type": "string"
           }
         },
+        "list.source.files.filterByName": {
+          "type": "boolean",
+          "default": false,
+          "description": "Filter files by name only"
+        },
         "list.source.mru.maxLength": {
           "type": "number",
           "default": 1000,
@@ -89,6 +94,11 @@
           "items": {
             "type": "string"
           }
+        },
+        "list.source.mru.filterByName": {
+          "type": "boolean",
+          "default": false,
+          "description": "Filter files by name only"
         },
         "list.source.grep.useLiteral": {
           "type": "boolean",


### PR DESCRIPTION
Its hard to find a file if it has a long path, especially for small window width.
vscode sytle makes the file name in front of line, which is really good for reading.

Before:
src/hello/world/coc/list/is/great/to/me/somefile.cpp
src/hello/world/coc/list/is/great/to/me/somefile.h

After:
**somefile.cpp** src/hello/world/coc/list/is/great/to/me/somefile.cpp
**somefile.h** src/hello/world/coc/list/is/great/to/me/somefile.h

Options `list.source.mru.filterByName` and `list.source.files.filterByName` are added to enable this feature for mru and files list.

When enabled, list is filtered by file names only.  