### PR TITLE
remove highlight group for file and mru lists

### DIFF
--- a/src/files.ts
+++ b/src/files.ts
@@ -171,9 +171,7 @@ Note that rg ignore hidden files by default.`
     if (filterByName) {
       let { nvim } = this 
       nvim.pauseNotification()
-      nvim.command('syntax match CocFilesName /\\v^[^\\t]+/ contained containedin=CocFilesLine', true)
       nvim.command('syntax match CocFilesFile /\\t.*$/ contained containedin=CocFilesLine', true)
-      nvim.command('highlight default link CocFilesName Identifier', true)
       nvim.command('highlight default link CocFilesFile Comment', true)
       nvim.resumeNotification(false, true)
     }

--- a/src/mru.ts
+++ b/src/mru.ts
@@ -123,9 +123,7 @@ export default class MruList extends BasicList {
     if (filterByName) {
       let { nvim } = this 
       nvim.pauseNotification()
-      nvim.command('syntax match CocMruName /\\v^[^\\t]+/ contained containedin=CocMruLine', true)
       nvim.command('syntax match CocMruFile /\\t.*$/ contained containedin=CocMruLine', true)
-      nvim.command('highlight default link CocMruName Identifier', true)
       nvim.command('highlight default link CocMruFile Comment', true)
       nvim.resumeNotification(false, true)
     }


### PR DESCRIPTION
Highlight group `CocListSearch` is weird in cursor line in neovim6
when setting hightligh group for filter text, which is ok in vim8.