### PR TITLE
jump to the exact line when invoke open action

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -40,10 +40,14 @@ export default class Commands implements IList {
         if (Array.isArray(item)) return
         let { command } = item.data
         if (!/^[A-Z]/.test(command)) return
-        let res = await nvim.eval(`split(execute("verbose command ${command}"),"\n")[-1]`) as string
+        let res = await nvim.eval(`split(execute("verbose command ${command}"),"\n")[2]`) as string
         if (/Last\sset\sfrom/.test(res)) {
-          let filepath = res.replace(/^\s+Last\sset\sfrom\s+/, '')
-          nvim.command(`edit +/${command} ${filepath}`, true)
+          let [filepath, _ ,line] = res.replace(/^\s+Last\sset\sfrom\s+/, '').split(/\s+/)
+          if (line) {
+            nvim.command(`edit +${line} ${filepath}`, true)
+          } else {
+            nvim.command(`edit +/${command} ${filepath}`, true)
+          }
         }
       }
     })

--- a/src/maps.ts
+++ b/src/maps.ts
@@ -20,7 +20,7 @@ export default class Maps implements IList {
         if (Array.isArray(item)) return
         let { mode, key } = item.data
         let cmd = JSON.stringify(`verbose ${mode}map ${key}`)
-        let res = await nvim.eval(`split(execute(${cmd}}),"\n")[-1]`) as string
+        let res = await nvim.eval(`split(execute(${cmd}),"\n")[-1]`) as string
         if (/Last\sset\sfrom/.test(res)) {
           // the format of the latest vim and neovim is:
           //   Last set from ~/dotfiles/vimrc/remap.vim line 183


### PR DESCRIPTION
we shouldn't get the last item from the output which invoked by `verbose command A`,
because the last item maybe a command  name lead with A like:
- A
- Abc
- Abd

so we should get the first item from the results
